### PR TITLE
addresses should be an array

### DIFF
--- a/turtlecoin/walletd.py
+++ b/turtlecoin/walletd.py
@@ -220,7 +220,7 @@ class Walletd:
         return self._make_request('getTransactionHashes', **params)
 
     def send_transaction(self, transfers, anonymity=3, fee=10,
-                         addresses='', change_address='', extra='',
+                         addresses=[], change_address='', extra='',
                          payment_id='', unlock_time=0):
         """
         Send a transaction to one or multiple addresses.


### PR DESCRIPTION
@arthurk what do you think of this.. Sabo from discord reported an error while sending transaction without specifying the addresses argument to the method and got an invalid request as response